### PR TITLE
Add Bluesky to social media links

### DIFF
--- a/_freeze/connect/execute-results/docx.json
+++ b/_freeze/connect/execute-results/docx.json
@@ -9,7 +9,7 @@
     ],
     "includes": {},
     "engineDependencies": {},
-    "preserve": {},
-    "postProcess": true
+    "preserve": null,
+    "postProcess": false
   }
 }

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -60,6 +60,8 @@ website:
         href: https://github.com/openscapes
       - icon: mastodon
         href: https://fosstodon.org/@openscapes
+      - icon: bluesky
+        href: https://bsky.app/profile/did:plc:5dyd34tl6z7jn4gjuqdo2y23
       - icon: envelope
         href: mailto:hello@openscapes.org
       - icon: rss

--- a/connect.qmd
+++ b/connect.qmd
@@ -39,7 +39,9 @@ knitr::include_graphics("images/minis/horst_openscapes_mountains_salmon.png")
 ## JOIN THE MOVEMENT
 
 -   Reuse our open lessons, slides, and more linked from our [media](media.qmd) and github: [\@openscapes](https://github.com/openscapes), [\@nasa-openscapes](https://github.com/nasa-openscapes)
--   Follow us on social media: [\@openscapes\@fosstodon.org](https://fosstodon.org/@openscapes) on Mastodon
+-   Follow us on social media: 
+    - Mastodon: [\@openscapes\@fosstodon.org](https://fosstodon.org/@openscapes)
+    - Bluesky: [\@openscapes.bsky.social](https://bsky.app/profile/did:plc:5dyd34tl6z7jn4gjuqdo2y23)
 -   Sign up for our [newsletter mailing list](https://docs.google.com/forms/d/e/1FAIpQLSd25jpfiAn1gYNwUPcfMVudsL625_pYbKsqxXpRazHCL6QA7g/viewform?usp=sf_link) (4x/year)
 -   Join an upcoming [event](events.qmd), including Openscapes initiatives, community calls, and talks
 -   Talk to your colleagues; consider [Supercharge your research](https://openscapes.github.io/supercharge-research/) or [Shifting institutional culture](https://eartharxiv.org/repository/view/5948/) for your next journal club or lab meeting


### PR DESCRIPTION
### Description
Add link to Bluesky:  
- top header where icons are
- in section: https://openscapes.org/connect#join-the-movement

### References
Towards #189 

### Preview

<img width="537" height="72" alt="Screenshot 2025-10-04 at 6 00 41 PM" src="https://github.com/user-attachments/assets/a8146220-7800-42b6-995e-88a964217818" />


<img width="803" height="304" alt="Screenshot 2025-10-04 at 6 00 56 PM" src="https://github.com/user-attachments/assets/46304a91-95c0-4512-a7c8-74cd8db30246" />
